### PR TITLE
Support arbitrary Ndefs

### DIFF
--- a/lib/Engine_Palouse.sc
+++ b/lib/Engine_Palouse.sc
@@ -28,69 +28,88 @@ Engine_Palouse : CroneEngine {
       Ndef(\bps).set(\bps, msg[1] /60);
     });
 
-  // Echo
-  context.server.sync;
-  ~delayBus = Bus.audio(context.server, 2);
-  context.server.sync;
+    // Echo
+    context.server.sync;
+    ~delayBus = Bus.audio(context.server, 2);
+    context.server.sync;
 
-    [\gye, \ixb, \lor, \mek, \vrs, \qpo].do({|x|
-      Ndef(x, {|t_trig=0, note=48, volume=1, mod=0, lag=0|
+    Ndef(\delay, {|beats=0.1, lag=0.1, decay=3.7|
+      var tr = 1/10000;
+      var delayTime = (beats / Ndef(\bps).max(0.1)).max(tr).lag(lag);
+      var out = In.ar(~delayBus.index, 2);
+      delayTime = SinOsc.kr(0.01, [0, pi/12], tr, delayTime + tr);
+      LeakDC.ar(CombC.ar(out, 2, delayTime, decay)).tanh;
+    }).play;
+
+    ("setup commands").postln;
+    this.addCommand("create", "s", {|msg|
+      var name = msg[1];
+
+      // create main ndef
+      Ndef(name, {|t_trig=0, note=48, volume=1, mod=0, lag=0|
         var env = t_trig.lagud(0, 0.2) * volume;
         note = note.lag(lag);
         mod = mod.lag(lag);
         SinOscFB.ar((note).midicps, mod, env) ! 2;
-    });
-    Ndef(x).(fadeTime: 2);
+      });
 
-    Ndef((x ++ \Strip).asSymbol, {
-    |volume=1, pan=0, delaySend=0, lag=1|
-    var delayOut;
+      // set main ndef fade time
+      Ndef(name).(fadeTime: 2);
+
+      // create "channel strip" ndef
+      Ndef((name ++ \Strip).asSymbol, {
+        |volume=1, pan=0, delaySend=0, lag=1|
+        var delayOut;
         var out = \in.ar(0 ! 2);
-    out = LeakDC.ar(out, mul: volume.lag(lag));
-    out = Balance2.ar(out[0], out[1], pan.lag(lag)).tanh;
-    Out.ar(~delayBus.index, out * delaySend);
-    out;
+
+        out = LeakDC.ar(out, mul: volume.lag(lag));
+        out = Balance2.ar(out[0], out[1], pan.lag(lag)).tanh;
+
+        Out.ar(~delayBus.index, out * delaySend);
+        out;
       }).play;
 
-    Ndef((x ++ \Strip).asSymbol) <<>.in Ndef(x);
+      // plug main ndef into strip ndef
+      Ndef((name ++ \Strip).asSymbol) <<>.in Ndef(name);
     });
 
-  Ndef(\delay, {|beats=0.1, lag=0.1, decay=3.7|
-    var tr = 1/10000;
-    var delayTime = (beats / Ndef(\bps).max(0.1)).max(tr).lag(lag);
-    var out = In.ar(~delayBus.index, 2);
-    delayTime = SinOsc.kr(0.01, [0, pi/12], tr, delayTime + tr);
-    LeakDC.ar(CombC.ar(out, 2, delayTime, decay)).tanh;
-  }).play;
+    this.addCommand("free", "s", {|msg|
+      var name = msg[1];
 
-  ("setup commands").postln;
-  this.addCommand("level", "sf", {|msg|
-    Ndef((msg[1] ++ "Strip").asSymbol).set(\volume, msg[2]);
+      // free main ndef
+      Ndef((name ++ \Strip).asSymbol).free;
+
+      // free "channel strip" ndef
+      Ndef((name ++ \Strip).asSymbol).free;
     });
 
-  this.addCommand("pan", "sf", {|msg|
-      ("lag for"+msg[1]+"set to"+msg[2]).postln;
-    Ndef((msg[1] ++ "Strip").asSymbol).set(\pan, msg[2]);
+    this.addCommand("level", "sf", {|msg|
+      Ndef((msg[1] ++ "Strip").asSymbol).set(\volume, msg[2]);
     });
 
-  this.addCommand("lag", "sf", {|msg|
-    Ndef((msg[1] ++ "Strip").asSymbol).set(\lag, msg[2]);
+    this.addCommand("pan", "sf", {|msg|
+        ("lag for"+msg[1]+"set to"+msg[2]).postln;
+      Ndef((msg[1] ++ "Strip").asSymbol).set(\pan, msg[2]);
+      });
+
+    this.addCommand("lag", "sf", {|msg|
+      Ndef((msg[1] ++ "Strip").asSymbol).set(\lag, msg[2]);
     });
 
-  this.addCommand("send_delay", "sf", {|msg|
-    Ndef((msg[1] ++ "Strip").asSymbol).set(\delaySend, msg[2]);
+    this.addCommand("send_delay", "sf", {|msg|
+      Ndef((msg[1] ++ "Strip").asSymbol).set(\delaySend, msg[2]);
     });
 
-  this.addCommand("delay_beats", "f", {|msg|
-    Ndef(\delay).set(\beats, msg[1]);
+    this.addCommand("delay_beats", "f", {|msg|
+      Ndef(\delay).set(\beats, msg[1]);
     });
 
-  this.addCommand("delay_lag", "f", {|msg|
-    Ndef(\delay).set(\lag, msg[1]);
+    this.addCommand("delay_lag", "f", {|msg|
+      Ndef(\delay).set(\lag, msg[1]);
     });
 
-  this.addCommand("delay_decay", "f", {|msg|
-    Ndef(\delay).set(\decay, msg[1]);
+    this.addCommand("delay_decay", "f", {|msg|
+      Ndef(\delay).set(\decay, msg[1]);
     });
 
     this.addCommand("trig", "sf", {|msg|
@@ -117,6 +136,7 @@ Engine_Palouse : CroneEngine {
         Ndef(msg[1].asSymbol).set(cmd.asSymbol, msg[2])
       })
     });
+    // done commands
   }
 
   free {


### PR DESCRIPTION
Move "ancients" initialization to on-demand engine command to create an arbitray Ndef on the fly. These can also be freed via an engine command. Each has its own "channel strip" Ndef as well, which is also freed with via the same channel command.